### PR TITLE
Fix #8 and other improvement

### DIFF
--- a/unlinkis.user.js
+++ b/unlinkis.user.js
@@ -113,6 +113,10 @@ function tweet_handler(elem) {
 
       if (match !== null) {
         convert_and_patch(links[i].href, $(links[i]), 0);
+        var media_url = $(elem).find('a.PlayableMedia-externalUrl');
+        if (media_url.length > 0) {
+          convert_and_patch(media_url[0].href, media_url, 0);
+        }
       }
     }
   }

--- a/unlinkis.user.js
+++ b/unlinkis.user.js
@@ -89,9 +89,17 @@ function tweet_handler(elem) {
   if (elem.tagName == 'IFRAME' && card_iframe_regex.test(elem.id)) {
     $(elem).on('load', function (event) {
       var card_hostname = elem.contentWindow.document.querySelector('span.SummaryCard-destination');
-      if (card_hostname !== null && linkis_card_detect.test(card_hostname.textContent)) {
+      if (card_hostname === null) return;
+      if (linkis_card_detect.test(card_hostname.textContent)) {
         var link = elem.contentWindow.document.querySelector('a.js-openLink');
         convert_and_patch(link.href, $(link), 0);
+      } else {
+        var twt_link = $(elem).closest('.tweet').find('a.twitter-timeline-link');
+        var xpurl = twt_link.data('expanded-url');
+        if (linkis_detect.test(xpurl)) {
+          var link = elem.contentWindow.document.querySelector('a.js-openLink');
+          convert_and_patch(link.href, $(link), 0);
+        }
       }
     });
   } else {

--- a/unlinkis.user.js
+++ b/unlinkis.user.js
@@ -112,7 +112,14 @@ function tweet_handler(elem) {
       var match = $(links[i]).text().match(linkis_detect);
 
       if (match !== null) {
-        convert_and_patch(links[i].href, $(links[i]), 0);
+        var url = links[i].href;
+        // expanded-url is for Twitter, full-url is for TweetDeck
+        if (links[i].hasAttribute('data-expanded-url')) {
+          url = links[i].getAttribute('data-expanded-url');
+        } else if (links[i].hasAttribute('data-full-url')) {
+          url = links[i].getAttribute('data-full-url');
+        }
+        convert_and_patch(url, $(links[i]), 0);
         var media_url = $(elem).find('a.PlayableMedia-externalUrl');
         if (media_url.length > 0) {
           convert_and_patch(media_url[0].href, media_url, 0);


### PR DESCRIPTION
- Fix issue #8 (zn@8a1df8c94afe9d6f0cf188c08c8dcda643368c5c)
- Some media link (e.g. "View on Vine" on tweet with vine video) convert correctly (zn@b1fef64158f44b36257a5a7916794b66e82c0a60)
- If link has `data-expanded-url`(or `data-full-url` on TweetDeck), use it instead of `href` attribute. (so unlinkis will skip first t.co url redirect) (zn@09466ab92c04f567aa0032d37540b4ef545b5922)
